### PR TITLE
Streaming deserialization function support.

### DIFF
--- a/MessagePack.h
+++ b/MessagePack.h
@@ -7,5 +7,6 @@
 
 #import "MessagePackPacker.h"
 #import "MessagePackParser.h"
+#import "MessagePackParser+Streaming.h"
 
 #endif

--- a/MessagePackParser+Streaming.h
+++ b/MessagePackParser+Streaming.h
@@ -2,8 +2,8 @@
 //  MessagePackParser+Streaming.h
 //  msgpack-objectivec-example
 //
-//  Created by 松前 健太郎 on 2013/01/18.
-//  Copyright (c) 2013年 kenmaz.net. All rights reserved.
+//  Created by Kentaro Matsumae on 2013/01/18.
+//  Copyright (c) 2013 kenmaz.net. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/MessagePackParser+Streaming.h
+++ b/MessagePackParser+Streaming.h
@@ -1,6 +1,6 @@
 //
 //  MessagePackParser+Streaming.h
-//  msgpack-objectivec-example
+//  msgpack-objectivec
 //
 //  Created by Kentaro Matsumae on 2013/01/18.
 //  Copyright (c) 2013 kenmaz.net. All rights reserved.

--- a/MessagePackParser+Streaming.h
+++ b/MessagePackParser+Streaming.h
@@ -1,0 +1,19 @@
+//
+//  MessagePackParser+Streaming.h
+//  msgpack-objectivec-example
+//
+//  Created by 松前 健太郎 on 2013/01/18.
+//  Copyright (c) 2013年 kenmaz.net. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MessagePackParser.h"
+
+@interface MessagePackParser (Streaming)
+
+- (id)init;
+- (id)initWithBufferSize:(int)bufferSize;
+- (void)feed:(NSData*)rawData;
+- (id)next;
+
+@end

--- a/MessagePackParser+Streaming.m
+++ b/MessagePackParser+Streaming.m
@@ -1,0 +1,56 @@
+//
+//  MessagePackParser+Streaming.m
+//  msgpack-objectivec-example
+//
+//  Created by 松前 健太郎 on 2013/01/18.
+//  Copyright (c) 2013年 kenmaz.net. All rights reserved.
+//
+
+#import "MessagePackParser+Streaming.h"
+
+static const int kUnpackerBufferSize = 1024;
+
+@interface MessagePackParser ()
+// Implemented in MessagePackParser.m
++(id) createUnpackedObject:(msgpack_object)obj;
+@end
+
+@implementation MessagePackParser (Streaming)
+
+- (id)init {
+    return [self initWithBufferSize:kUnpackerBufferSize];
+}
+
+- (id)initWithBufferSize:(int)bufferSize {
+    if (self = [super init]) {
+        msgpack_unpacker_init(&unpacker, bufferSize);
+    }
+    return self;
+}
+
+// Feed chunked messagepack data into buffer.
+- (void)feed:(NSData*)chunk {
+    msgpack_unpacker_reserve_buffer(&unpacker, [chunk length]);
+    memcpy(msgpack_unpacker_buffer(&unpacker), [chunk bytes], [chunk length]);
+    msgpack_unpacker_buffer_consumed(&unpacker, [chunk length]);
+}
+
+// Put next parsed messagepack data. If there is not sufficient data, return nil.
+- (id)next {
+    id unpackedObject;
+    msgpack_unpacked result;
+    msgpack_unpacked_init(&result);
+    if (msgpack_unpacker_next(&unpacker, &result)) {
+        msgpack_object obj = result.data;
+        unpackedObject = [MessagePackParser createUnpackedObject:obj];
+    }
+    msgpack_unpacked_destroy(&result);
+    
+#if !__has_feature(objc_arc)
+    return [unpackedObject autorelease];
+#else
+    return unpackedObject;
+#endif
+}
+
+@end

--- a/MessagePackParser+Streaming.m
+++ b/MessagePackParser+Streaming.m
@@ -1,6 +1,6 @@
 //
 //  MessagePackParser+Streaming.m
-//  msgpack-objectivec-example
+//  msgpack-objectivec
 //
 //  Created by Kentaro Matsumae on 2013/01/18.
 //  Copyright (c) 2013 kenmaz.net. All rights reserved.

--- a/MessagePackParser+Streaming.m
+++ b/MessagePackParser+Streaming.m
@@ -2,8 +2,8 @@
 //  MessagePackParser+Streaming.m
 //  msgpack-objectivec-example
 //
-//  Created by 松前 健太郎 on 2013/01/18.
-//  Copyright (c) 2013年 kenmaz.net. All rights reserved.
+//  Created by Kentaro Matsumae on 2013/01/18.
+//  Copyright (c) 2013 kenmaz.net. All rights reserved.
 //
 
 #import "MessagePackParser+Streaming.h"

--- a/MessagePackParser.h
+++ b/MessagePackParser.h
@@ -12,4 +12,9 @@
 
 + (id)parseData:(NSData*)data;
 
+- (id)init;
+- (id)initWithBufferSize:(int)bufferSize;
+- (void)feed:(NSData*)rawData;
+- (id)next;
+
 @end

--- a/MessagePackParser.h
+++ b/MessagePackParser.h
@@ -7,14 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#include "msgpack_src/msgpack.h"
 
-@interface MessagePackParser : NSObject
+@interface MessagePackParser : NSObject {
+    // This is only for MessagePackParser+Streaming category.
+    msgpack_unpacker unpacker;
+}
 
 + (id)parseData:(NSData*)data;
-
-- (id)init;
-- (id)initWithBufferSize:(int)bufferSize;
-- (void)feed:(NSData*)rawData;
-- (id)next;
 
 @end

--- a/MessagePackParser.m
+++ b/MessagePackParser.m
@@ -9,7 +9,7 @@
 #import "MessagePackParser.h"
 #include "msgpack_src/msgpack.h"
 
-#define UNPACKER_BUFFER_SIZE 1024
+static const int kUnpackerBufferSize = 1024;
 
 @implementation MessagePackParser {
     msgpack_unpacker unpacker;
@@ -87,7 +87,7 @@
 #pragma mark - Stremaing Deserializer
 
 - (id)init {
-    return [self initWithBufferSize:UNPACKER_BUFFER_SIZE];
+    return [self initWithBufferSize:kUnpackerBufferSize];
 }
 
 - (id)initWithBufferSize:(int)bufferSize {

--- a/MessagePackParser.m
+++ b/MessagePackParser.m
@@ -7,13 +7,8 @@
 //
 
 #import "MessagePackParser.h"
-#include "msgpack_src/msgpack.h"
 
-static const int kUnpackerBufferSize = 1024;
-
-@implementation MessagePackParser {
-    msgpack_unpacker unpacker;
-}
+@implementation MessagePackParser
 
 // This function returns a parsed object that you have the responsibility to release/autorelease (see 'create rule' in apple docs)
 +(id) createUnpackedObject:(msgpack_object)obj {
@@ -81,44 +76,6 @@ static const int kUnpackerBufferSize = 1024;
 	return [results autorelease];
 #else
     return results;
-#endif
-}
-
-#pragma mark - Streaming Deserializer
-
-- (id)init {
-    return [self initWithBufferSize:kUnpackerBufferSize];
-}
-
-- (id)initWithBufferSize:(int)bufferSize {
-    if (self = [super init]) {
-        msgpack_unpacker_init(&unpacker, bufferSize);
-    }
-    return self;
-}
-
-// Feed chunked messagepack data into buffer.
-- (void)feed:(NSData*)chunk {
-    msgpack_unpacker_reserve_buffer(&unpacker, [chunk length]);
-    memcpy(msgpack_unpacker_buffer(&unpacker), [chunk bytes], [chunk length]);
-    msgpack_unpacker_buffer_consumed(&unpacker, [chunk length]);
-}
-
-// Put next parsed messagepack data. If there is not sufficient data, return nil.
-- (id)next {
-    id unpackedObject;
-    msgpack_unpacked result;
-    msgpack_unpacked_init(&result);
-    if (msgpack_unpacker_next(&unpacker, &result)) {
-        msgpack_object obj = result.data;
-        unpackedObject = [[self class] createUnpackedObject:obj];
-    }
-    msgpack_unpacked_destroy(&result);
-    
-#if !__has_feature(objc_arc)
-    return [unpackedObject autorelease];
-#else
-    return unpackedObject;
 #endif
 }
 

--- a/MessagePackParser.m
+++ b/MessagePackParser.m
@@ -84,7 +84,7 @@ static const int kUnpackerBufferSize = 1024;
 #endif
 }
 
-#pragma mark - Stremaing Deserializer
+#pragma mark - Streaming Deserializer
 
 - (id)init {
     return [self initWithBufferSize:kUnpackerBufferSize];


### PR DESCRIPTION
Add streaming deserialization function to MessagePackParser class.
It's useful for some network applications.

Streaming deserialization:
http://wiki.msgpack.org/display/MSGPACK/QuickStart+for+C+Language#QuickStartforCLanguage-Streamingfeature

For demonstration, I create a sample iOS application using this function.
https://github.com/kenmaz/msgpack-objectivec-example
